### PR TITLE
readme: fix markup inside spoilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ Non-determinism is a source of test flakiness.
 
 <details>
   <summary>References</summary>
+
 - **An empirical analysis of flaky tests** - Qingzhou  Luo, Farah  Hariri, Lamyaa  Eloussi, Darko  Marinov
 - **Empirical Analysis of Factors and their Effect on Test Flakiness - Practitioners’ Perceptions** - Azeem Ahmad, Ola Leifler, Kristian Sandahl
 - **Root Causing Flaky Tests in a Large-Scale Industrial Setting** - Wing Lam, Patrice Godefroid, Suman Nath, Anirudh Santhiar, Suresh Thummalapenta
 - **What is the Vocabulary of Flaky Tests?** - Gustavo Pinto, Breno Miranda, Supun Dissanayake, Marcelo d'Amorim, Christoph Treude, Antonia Bertolino
 - **Eradicating Non-Determinism in Tests** - Martin Fowler
+
 </details>
 
 ### Error handling
@@ -42,8 +44,10 @@ finds serious bugs in Java exception handler.
 
 <details>
   <summary>References</summary>
+
 - **The Do's and Don'ts of Error Handling** - Joe Armstrong (GOTO 2018)
 - **Finding Error-Handling Bugs in Systems Code Using Static Analysis** - Cindy Rubio-González, Ben Liblit
 - **Simple Testing Can Prevent Most Critical Failures: An Analysis of Production Failures in Distributed Data-Intensive Systems** - Ding Yuan, Yu Luo, Xin Zhuang, Guilherme Renna Rodrigues, Xu Zhao, Yongle Zhang, Pranay U. Jain, and Michael Stumm, University of Toronto (USENIX)
 - **Improving the Quality of Error-Handling Code in Systems Software using Function-Local Information** - Suman Saha
+
 </details>


### PR DESCRIPTION
commit 81d74d65b057e13ce5d8735bcfcb0618ec57be92 "readme: hide references with spoilers" added spoilers with missed newlines. Patch fixes that.